### PR TITLE
Enables the UI to be moved by dragging

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,11 +1,10 @@
 .p5c-container {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 12px;
+  left: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin: 12px;
   padding: 10px;
   font-family: Menlo, Consolas, monospace;
   font-size: 1rem;
@@ -15,6 +14,7 @@
   text-shadow: 2px 2px 4px #4a5568, 2px -2px 4px #4a5568, -2px 2px 4px #4a5568,
     -2px -2px 4px #4a5568;
   box-shadow: 0 0 4px #4a5568;
+  cursor: move;
 }
 .p5c-main {
   display: flex;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -26,6 +26,29 @@ export const getEncodingProgressStr = (progress?: number) => {
   return `encoding ${percentage}%`;
 };
 
+const setDraggable = (container: HTMLDivElement) => {
+  let mousePos = { x: 0, y: 0 };
+  let containerPos = { x: 0, y: 0 };
+  let isDragging = false;
+
+  container.addEventListener("mousedown", (e) => {
+    isDragging = true;
+    mousePos = { x: e.pageX, y: e.pageY };
+    containerPos = { x: container.offsetLeft, y: container.offsetTop };
+  });
+
+  document.addEventListener("mouseup", () => {
+    isDragging = false;
+  });
+
+  document.addEventListener("mousemove", (e) => {
+    if (!isDragging) return;
+    const diff = { x: e.pageX - mousePos.x, y: e.pageY - mousePos.y };
+    container.style.left = `${containerPos.x + diff.x}px`;
+    container.style.top = `${containerPos.y + diff.y}px`;
+  });
+};
+
 const createStyle = (parent: HTMLElement) => {
   const style = document.createElement("style");
   style.innerHTML = styleStr;
@@ -35,6 +58,7 @@ const createStyle = (parent: HTMLElement) => {
 const createContainer = (parent: HTMLElement) => {
   const container = document.createElement("div");
   container.classList.add("p5c-container", "idle");
+  setDraggable(container);
   parent.appendChild(container);
   return { container };
 };


### PR DESCRIPTION
Enables the UI to be moved by dragging.

In Firefox, pageX / pageY does not work on drag event. (See [505521 - Set screen coordinates during HTML5 drag event](https://bugzilla.mozilla.org/show_bug.cgi?id=505521))
Therefore, I implemented it with the monsedown, mouseup, and mousemove events.
There is a workaround using the dragover event, but I gave up on it because dragging in Firefox is not smooth.

This PR is related to #1