### PR TITLE
Fix the issue of installation failure via npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Make sure you have Node.js and Yarn installed.
 
 1. Fork this repository and clone your fork
 2. Install dependencies: `yarn install`
+3. Install browsers for E2E test: `yarn setup`
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "format": "prettier --write .",
-    "postinstall": "playwright install",
+    "setup": "playwright install",
     "prepublishOnly": "yarn build && yarn test:unit run && yarn test:e2e:skipbuild",
     "test:e2e": "playwright test",
     "test:e2e:skipbuild": "SKIP_BUILD=true yarn test:e2e",


### PR DESCRIPTION
`npm install p5.capture` fails because the `postinstall` script is running at an unintended time.

Close #4 