### PR TITLE
Support segmented capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,18 +173,19 @@ function keyPressed() {
 
 ## Options
 
-| Name           | Default                               | Description                                                                                   |
-| -------------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| format         | `"webm"`                              | export format. `"webm"`, `"gif"`, `"mp4"`, `"png"`, `"jpg"`, and `"webp"`                     |
-| framerate      | `30`                                  | recording framerate                                                                           |
-| bitrate        | `5000`                                | recording bitrate in kbps, only valid for MP4                                                 |
-| quality        | see [Quality option](#quality-option) | recording quality from `0` (worst) to `1` (best), valid for WebM, GIF, JPG, WebP              |
-| width          | canvas width                          | output image width                                                                            |
-| height         | canvas height                         | output image height                                                                           |
-| duration       | `null`                                | maximum recording duration in number of frames                                                |
-| verbose        | `false`                               | dumps info on the console                                                                     |
-| disableUi      | `false`                               | (only `P5Capture.setDefaultOptions()`) hides the UI                                           |
-| disableScaling | `false`                               | (only `P5Capture.setDefaultOptions()`) disables pixel scaling for high pixel density displays |
+| Name             | Default                               | Description                                                                                            |
+| ---------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| format           | `"webm"`                              | export format. `"webm"`, `"gif"`, `"mp4"`, `"png"`, `"jpg"`, and `"webp"`                              |
+| framerate        | `30`                                  | recording framerate                                                                                    |
+| bitrate          | `5000`                                | recording bitrate in kbps (only available for MP4)                                                     |
+| quality          | see [Quality option](#quality-option) | recording quality from `0` (worst) to `1` (best). (only available for WebM/GIF/JPG/WebP)               |
+| width            | canvas width                          | output image width                                                                                     |
+| height           | canvas height                         | output image height                                                                                    |
+| duration         | `null`                                | maximum recording duration in number of frames                                                         |
+| autoSaveDuration | `null`                                | automatically downloads every n frames. convenient for long captures (only available for PNG/JPG/WebP) |
+| verbose          | `false`                               | dumps info on the console                                                                              |
+| disableUi        | `false`                               | (only `P5Capture.setDefaultOptions()`) hides the UI                                                    |
+| disableScaling   | `false`                               | (only `P5Capture.setDefaultOptions()`) disables pixel scaling for high pixel density displays          |
 
 ### Quality option
 

--- a/scripts/README.template.md
+++ b/scripts/README.template.md
@@ -171,18 +171,19 @@ function keyPressed() {
 
 ## Options
 
-| Name           | Default                               | Description                                                                                   |
-| -------------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
-| format         | `"webm"`                              | export format. `"webm"`, `"gif"`, `"mp4"`, `"png"`, `"jpg"`, and `"webp"`                     |
-| framerate      | `30`                                  | recording framerate                                                                           |
-| bitrate        | `5000`                                | recording bitrate in kbps, only valid for MP4                                                 |
-| quality        | see [Quality option](#quality-option) | recording quality from `0` (worst) to `1` (best), valid for WebM, GIF, JPG, WebP              |
-| width          | canvas width                          | output image width                                                                            |
-| height         | canvas height                         | output image height                                                                           |
-| duration       | `null`                                | maximum recording duration in number of frames                                                |
-| verbose        | `false`                               | dumps info on the console                                                                     |
-| disableUi      | `false`                               | (only `P5Capture.setDefaultOptions()`) hides the UI                                           |
-| disableScaling | `false`                               | (only `P5Capture.setDefaultOptions()`) disables pixel scaling for high pixel density displays |
+| Name             | Default                               | Description                                                                                            |
+| ---------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| format           | `"webm"`                              | export format. `"webm"`, `"gif"`, `"mp4"`, `"png"`, `"jpg"`, and `"webp"`                              |
+| framerate        | `30`                                  | recording framerate                                                                                    |
+| bitrate          | `5000`                                | recording bitrate in kbps (only available for MP4)                                                     |
+| quality          | see [Quality option](#quality-option) | recording quality from `0` (worst) to `1` (best). (only available for WebM/GIF/JPG/WebP)               |
+| width            | canvas width                          | output image width                                                                                     |
+| height           | canvas height                         | output image height                                                                                    |
+| duration         | `null`                                | maximum recording duration in number of frames                                                         |
+| autoSaveDuration | `null`                                | automatically downloads every n frames. convenient for long captures (only available for PNG/JPG/WebP) |
+| verbose          | `false`                               | dumps info on the console                                                                              |
+| disableUi        | `false`                               | (only `P5Capture.setDefaultOptions()`) hides the UI                                                    |
+| disableScaling   | `false`                               | (only `P5Capture.setDefaultOptions()`) disables pixel scaling for high pixel density displays          |
 
 ### Quality option
 

--- a/src/p5.capture.ts
+++ b/src/p5.capture.ts
@@ -20,6 +20,7 @@ export type P5CaptureOptions = {
   width?: number;
   height?: number;
   duration?: number | null;
+  autoSaveDuration?: number | null;
   verbose?: boolean;
 };
 
@@ -30,9 +31,10 @@ export type P5CaptureGlobalOptions = P5CaptureOptions & {
 
 const defaultOptions: P5CaptureGlobalOptions = {
   format: "webm",
-  duration: null,
   framerate: 30,
   bitrate: 5000,
+  duration: null,
+  autoSaveDuration: null,
   verbose: false,
   disableUi: false,
   disableScaling: false,
@@ -175,8 +177,15 @@ export class P5Capture {
     }
 
     const canvas = (window as any).canvas;
-    const { format, framerate, bitrate, quality, width, height } =
-      this.mergedOptions;
+    const {
+      format,
+      framerate,
+      bitrate,
+      quality,
+      width,
+      height,
+      autoSaveDuration,
+    } = this.mergedOptions;
     let recorder;
 
     switch (format) {
@@ -217,6 +226,7 @@ export class P5Capture {
         const pngRecorderOptions: PngRecorderOptions = {
           width,
           height,
+          autoSaveDuration,
         };
         recorder = new PngRecorder(canvas, pngRecorderOptions);
         break;
@@ -226,6 +236,7 @@ export class P5Capture {
           quality,
           width,
           height,
+          autoSaveDuration,
         };
         recorder = new JpgRecorder(canvas, jpgRecorderOptions);
         break;
@@ -235,6 +246,7 @@ export class P5Capture {
           quality,
           width,
           height,
+          autoSaveDuration,
         };
         recorder = new WebpRecorder(canvas, webpRecorderOptions);
         break;
@@ -261,6 +273,10 @@ export class P5Capture {
       this.log("✅ done");
       downloadBlob(blob, filename);
       this.updateUi?.(framerate);
+    });
+    recorder.on("segmented", (blob, filename) => {
+      this.log(`💾 save segmented file: ${filename}`);
+      downloadBlob(blob, filename);
     });
     recorder.on("error", (error) => {
       console.error(error.message);

--- a/src/recorders/base.ts
+++ b/src/recorders/base.ts
@@ -14,6 +14,7 @@ type RecorderEmitter = StrictEventEmitter<
     added: void;
     progress: (progress: number) => void;
     finished: (blob: Blob, filename: string) => void;
+    segmented: (blob: Blob, filename: string) => void;
     error: (error: Error) => void;
   }
 >;

--- a/src/recorders/jpg-recorder.ts
+++ b/src/recorders/jpg-recorder.ts
@@ -1,7 +1,9 @@
-import { ImageRecorder } from "@/recorders/image-recorder";
-import { RecorderOptions } from "@/recorders/base";
+import {
+  ImageRecorder,
+  ImageRecorderOptions,
+} from "@/recorders/image-recorder";
 
-export type JpgRecorderOptions = RecorderOptions & {
+export type JpgRecorderOptions = ImageRecorderOptions & {
   quality?: number;
 };
 

--- a/src/recorders/png-recorder.ts
+++ b/src/recorders/png-recorder.ts
@@ -1,7 +1,9 @@
-import { ImageRecorder } from "@/recorders/image-recorder";
-import { RecorderOptions } from "@/recorders/base";
+import {
+  ImageRecorder,
+  ImageRecorderOptions,
+} from "@/recorders/image-recorder";
 
-export type PngRecorderOptions = RecorderOptions & {};
+export type PngRecorderOptions = ImageRecorderOptions & {};
 
 const defaultOptions: PngRecorderOptions = {};
 

--- a/src/recorders/webp-recorder.ts
+++ b/src/recorders/webp-recorder.ts
@@ -1,7 +1,9 @@
-import { ImageRecorder } from "@/recorders/image-recorder";
-import { RecorderOptions } from "@/recorders/base";
+import {
+  ImageRecorder,
+  ImageRecorderOptions,
+} from "@/recorders/image-recorder";
 
-export type WebpRecorderOptions = RecorderOptions & {
+export type WebpRecorderOptions = ImageRecorderOptions & {
   quality?: number;
 };
 

--- a/tests/e2e/auto-save-duration.test.ts
+++ b/tests/e2e/auto-save-duration.test.ts
@@ -1,0 +1,38 @@
+import { Download, expect } from "@playwright/test";
+import { test } from "./fixture";
+import fs from "fs/promises";
+
+const PAGE_PATH = "/tests/e2e/public/auto-save-duration.html";
+const IMAGE_FORMATS = ["png", "jpg", "webp"];
+
+IMAGE_FORMATS.forEach((format) => {
+  test(`download segmented zipped ${format} files`, async ({ page, port }) => {
+    await page.goto(`http://localhost:${port}${PAGE_PATH}`);
+
+    // Select format
+    await page.locator(".p5c-format").selectOption(format);
+
+    // Start capturing
+    await page.locator(".p5c-btn").click();
+
+    const downloads: Download[] = [];
+
+    // Wait for download first zip
+    downloads.push(await page.waitForEvent("download"));
+
+    // Wait for download second zip
+    downloads.push(await page.waitForEvent("download"));
+
+    for (const download of downloads) {
+      const filename = download.suggestedFilename();
+      const pattern = new RegExp(`^\\d{8}-\\d{6}\\.zip$`);
+      expect(filename).toMatch(pattern);
+
+      const path = await download.path();
+      expect(path).toBeTruthy();
+      const stats = await fs.stat(path!);
+      const fileSizeInBytes = stats.size;
+      expect(fileSizeInBytes).toBeGreaterThan(100);
+    }
+  });
+});

--- a/tests/e2e/public/auto-save-duration.html
+++ b/tests/e2e/public/auto-save-duration.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script src="https://cdn.jsdelivr.net/npm/p5"></script>
+    <script src="../../../dist/p5.capture.umd.js"></script>
+    <script>
+      P5Capture.setDefaultOptions({
+        format: "png",
+        duration: 30,
+        autoSaveDuration: 15,
+      });
+    </script>
+    <script src="./sketch.js"></script>
+  </head>
+  <body style="margin: 0"></body>
+</html>


### PR DESCRIPTION
Add `autoSaveDuration` option to automatically download every n frames. (only available for PNG/JPG/WebP)
This is convenient for long captures.

#6 