### PR TITLE
adding support to p5 instance mode with one singleton

### DIFF
--- a/src/p5.capture.ts
+++ b/src/p5.capture.ts
@@ -24,6 +24,7 @@ export type P5CaptureOptions = {
   baseFilename?: (date: Date) => string;
   imageFilename?: (index: number) => string;
   verbose?: boolean;
+  p5?: any;
 };
 
 export type P5CaptureGlobalOptions = P5CaptureOptions & {
@@ -40,6 +41,7 @@ const defaultOptions: P5CaptureGlobalOptions = {
   verbose: false,
   disableUi: false,
   disableScaling: false,
+  p5: window as any,
 };
 
 export class P5Capture {
@@ -106,6 +108,12 @@ export class P5Capture {
       throw new Error("options are not set");
     }
 
+    const p5 = this.mergedOptions.p5;
+
+    if(document === undefined || document.body === undefined) {
+      console.log("Trying to initialize p5.capture before the body has been loaded. To use p5.capture, p5 should be initialized only within or after <body>.");
+    }
+
     if (!this.mergedOptions.disableUi) {
       this.uiState = {
         format: this.mergedOptions.format,
@@ -153,12 +161,12 @@ export class P5Capture {
     }
 
     if (this.mergedOptions.disableScaling) {
-      const originalSetup = (window as any).setup as () => void;
+      const originalSetup = p5.setup as () => void;
       const newSetup = () => {
-        pixelDensity(1);
+        p5.pixelDensity(1);
         originalSetup();
       };
-      Object.assign(window, { setup: newSetup });
+      Object.assign(p5, { setup: newSetup });
     }
   }
 
@@ -178,7 +186,7 @@ export class P5Capture {
       throw new Error("options are not set");
     }
 
-    const canvas = (window as any).canvas;
+    const canvas = this.mergedOptions.p5.canvas;
     const {
       format,
       framerate,

--- a/tests/e2e/instance-mode.test.ts
+++ b/tests/e2e/instance-mode.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixture";
+import fs from "fs/promises";
+import { IMAGE_FORMATS, VIDEO_FORMATS } from "./helper";
+
+const PAGE_PATH = "/tests/e2e/public/instance-mode.html";
+const CAPTURE_TIME = 200;
+
+test("display the ui", async ({ page, port }) => {
+  await page.goto(`http://localhost:${port}${PAGE_PATH}`);
+  const container = page.locator(".p5c-container");
+  await expect(container).toBeVisible();
+  await expect(container).toHaveClass(/idle/);
+});
+
+VIDEO_FORMATS.forEach((format) => {
+  test(`download ${format} video`, async ({ page, port }) => {
+    await page.goto(`http://localhost:${port}${PAGE_PATH}`);
+
+    // Select format
+    await page.locator(".p5c-format").selectOption(format);
+
+    // Start capturing
+    await page.locator(".p5c-btn").click();
+
+    await page.waitForTimeout(CAPTURE_TIME);
+
+    // Stop capturing & download
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator(".p5c-btn").click(),
+    ]);
+
+    const filename = await download.suggestedFilename();
+    const pattern = new RegExp(`^\\d{8}-\\d{6}\\.${format}$`);
+    expect(filename).toMatch(pattern);
+
+    const path = await download.path();
+    expect(path).toBeTruthy();
+    const stats = await fs.stat(path!);
+    const fileSizeInBytes = stats.size;
+    expect(fileSizeInBytes).toBeGreaterThan(100);
+  });
+});
+
+IMAGE_FORMATS.forEach((format) => {
+  test(`download zipped ${format} files`, async ({ page, port }) => {
+    await page.goto(`http://localhost:${port}${PAGE_PATH}`);
+
+    // Select format
+    await page.locator(".p5c-format").selectOption(format);
+
+    // Start capturing
+    await page.locator(".p5c-btn").click();
+
+    await page.waitForTimeout(CAPTURE_TIME);
+
+    // Stop capturing & download
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator(".p5c-btn").click(),
+    ]);
+
+    const filename = await download.suggestedFilename();
+    const pattern = new RegExp(`^\\d{8}-\\d{6}\\.zip$`);
+    expect(filename).toMatch(pattern);
+
+    const path = await download.path();
+    expect(path).toBeTruthy();
+    const stats = await fs.stat(path!);
+    const fileSizeInBytes = stats.size;
+    expect(fileSizeInBytes).toBeGreaterThan(100);
+  });
+});

--- a/tests/e2e/public/instance-mode.html
+++ b/tests/e2e/public/instance-mode.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script src="https://cdn.jsdelivr.net/npm/p5"></script>
+    <script src="../../../dist/p5.capture.umd.js"></script>
+  </head>
+  <body style="margin: 0">
+    <script src="./instance-sketch.js"></script>
+</body>
+</html>

--- a/tests/e2e/public/instance-sketch.js
+++ b/tests/e2e/public/instance-sketch.js
@@ -1,0 +1,21 @@
+/// <reference types="p5/global" />
+/// <reference path="../../../index.d.ts" />
+
+const s = ( sketch ) => {
+
+    sketch.setup = () => {
+        sketch.createCanvas(480, 480, sketch.WEBGL);
+        sketch.frameRate(30);
+        P5Capture.setDefaultOptions({p5 : sketch});
+    };
+
+    sketch.draw = () => {
+        sketch.background(0);
+        sketch.normalMaterial();
+        sketch.rotateX(sketch.frameCount * 0.02);
+        sketch.rotateY(sketch.frameCount * 0.03);
+        sketch.torus(sketch.width * 0.2, sketch.width * 0.1, 64, 64);
+    };
+};
+  
+new p5(s);


### PR DESCRIPTION
This commit adds support for p5 instance mode, allowing the user to record one canvas at a time (any p5 canvas within the page).

Usage is straightforward. As expected, after the canvas is set up, P5Capture is told to use that p5 instance and canvas instead of `window`.

```
const s = ( sketch ) => {

    sketch.setup = () => {
        // your setup
        P5Capture.setDefaultOptions({p5 : sketch});
    };

    sketch.draw = () => {
        // your draw
    };
};

new p5(s);```

That is all. I have also included:
- the proper end to end tests
- A safety check to warn if one tries to load p5.capture before the document body has been created. You can't load it before document.body as there would be nowhere for the recording window to be appended to

If this implementation makes sense I can add this example to the Readme to finish it.

I did not choose to support multiple recording sessions running at the same time inside a single page since:
- it seems to be an even more rare situation
- it would require to remove the singleton pattern of the P5.Capture, which is not a minor feature

I guess that is all, thanks for the great work.