### PR TITLE
ci: minimize GITHUB_TOKEN permissions in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,10 @@ name: Check
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `permissions: contents: read` をワークフローレベルで追加
- GITHUB_TOKEN のデフォルト権限（書き込みを含む広い権限）を最小化
- 侵害されたアクションが GITHUB_TOKEN を悪用してリポジトリに書き込むリスクを遮断

## 背景

サプライチェーン攻撃対策の一環。2025年3月の tj-actions/changed-files 侵害のように、利用中のアクションが悪意あるコードに差し替えられた場合でも、GITHUB_TOKEN の権限を絞っておくことで被害範囲を限定できる。

このワークフローはチェック（ビルド・テスト）のみを行うため `contents: read` のみで十分。

## Test plan

- [x] PR を push して Check ワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)