### PR TITLE
chore: add PostToolUse hook to auto-format after edits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm format 2>/dev/null || true",
+            "statusMessage": "フォーマット中..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- `.claude/settings.json` を新規作成し、プロジェクトレベルの Claude Code フック設定を追加
- `Edit` / `Write` / `NotebookEdit` ツール完了後に `pnpm format` を自動実行
- チーム全員に適用されるプロジェクト設定として追加

## Test plan

- [x] Claude Code で任意のソースファイルを編集した後、自動的に Prettier フォーマットが走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)