### PR TITLE
chore: update fflate from 0.7.4 to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "events": "3.3.0",
-    "fflate": "0.7.4",
+    "fflate": "0.8.2",
     "gif.js": "0.2.0",
     "h264-mp4-encoder": "1.0.12",
     "webm-writer": "1.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 3.3.0
         version: 3.3.0
       fflate:
-        specifier: 0.7.4
-        version: 0.7.4
+        specifier: 0.8.2
+        version: 0.8.2
       gif.js:
         specifier: 0.2.0
         version: 0.2.0
@@ -600,8 +600,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1220,7 +1220,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fflate@0.7.4: {}
+  fflate@0.8.2: {}
 
   fsevents@2.3.2:
     optional: true


### PR DESCRIPTION
## Summary

- `fflate` を 0.7.4 → 0.8.2 に更新
- 他の dependencies（events, gif.js, h264-mp4-encoder, webm-writer）は既に最新のため変更なし

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm test:unit run` 全パス (52 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)