### PR TITLE
chore: translate statusMessage to English

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "pnpm format 2>/dev/null || true",
-            "statusMessage": "フォーマット中..."
+            "statusMessage": "Formatting..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の `statusMessage` を日本語（`フォーマット中...`）から英語（`Formatting...`）に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)